### PR TITLE
Trabajo relacionado

### DIFF
--- a/articulo/.gitignore
+++ b/articulo/.gitignore
@@ -1,3 +1,4 @@
 *.aux
 *.log
 *.pdf
+.*.swp

--- a/articulo/main.tex
+++ b/articulo/main.tex
@@ -338,6 +338,9 @@ Email: john.sanabria@correounivalle.edu.co}
 \bibitem{rad2017introduction}
 Rad, B., Bhatti, H. \& Ahmadi, M. An introduction to docker and analysis of its performance.  {\em International Journal Of Computer Science And Network Security (ijcsns)}.  \textbf{17}, 228 (2017).
 
+\bibitem{torrez2019hpc}
+Torrez, A., Les, T. \& Priedhorsky, R. HPC container runtimes have minimal or no performance impact. {\em 2019 IEEE/ACM International Workshop on Containers and New Orchestration Paradigms for Isolated Environments in HPC (CANOPIE-HPC)}. \textbf{37--42}, (2019).
+
 \end{thebibliography}
 
 

--- a/articulo/main.tex
+++ b/articulo/main.tex
@@ -335,9 +335,8 @@ Email: john.sanabria@correounivalle.edu.co}
 % (used to reserve space for the reference number labels box)
 \begin{thebibliography}{1}
 
-\bibitem{IEEEhowto:kopka}
-H.~Kopka and P.~W. Daly, \emph{A Guide to \LaTeX}, 3rd~ed.\hskip 1em plus
-  0.5em minus 0.4em\relax Harlow, England: Addison-Wesley, 1999.
+\bibitem{rad2017introduction}
+Rad, B., Bhatti, H. \& Ahmadi, M. An introduction to docker and analysis of its performance.  {\em International Journal Of Computer Science And Network Security (ijcsns)}.  \textbf{17}, 228 (2017).
 
 \end{thebibliography}
 

--- a/articulo/referencias/README.md
+++ b/articulo/referencias/README.md
@@ -1,0 +1,38 @@
+# Convertir de bibtex a bibitem
+
+La forma como se están manejando las referencias en este artículo es a través de *bibitem*. 
+En este caso las referencias están definidas en el archivo [main.tex](../main.tex). 
+
+Referencias de tipo *bibtex* se pueden encontrar "fácilmente" pero es necesario pasarlas a *bibitem* que es el formato que se usa en este artículo.
+Se [ha encontrado un código en python](https://tex.stackexchange.com/questions/124874/converting-to-bibitem-in-latex) que convierte de *bibtex* a *bibitem*. 
+El código se encontraba en Python2 y con ayuda de la herramienta [2to3](https://docs.python.org/3/library/2to3.html) fue posible pasar el código de Python2 a Python3, [código](bibtex2item.py). 
+
+Asumamos que tenemos el siguiente código de *bibtex*:
+
+```
+@article{rad2017introduction,
+  title={An introduction to docker and analysis of its performance},
+  author={Rad, Babak Bashari and Bhatti, Harrison John and Ahmadi, Mohammad},
+  journal={International Journal of Computer Science and Network Security (IJCSNS)},
+  volume={17},
+  number={3},
+  pages={228},
+  year={2017},
+  publisher={International Journal of Computer Science and Network Security}
+}
+```
+
+Y está en el archivo `entrada.bib` para convertir este *bibtex* a *bibitem* se ejecuta lo siguiente:
+
+```
+python3 bibtex2item.py < entrada.bib > salida.bib
+```
+
+Esto da como salida en el archivo `salida.bib` lo siguiente:
+
+```
+\bibitem{rad2017introduction}
+Rad, B., Bhatti, H. & Ahmadi, M. An introduction to docker and analysis of its performance.  {\em International Journal Of Computer Science And Network Security (ijcsns)}.  \textbf{17}, 228 (2017)
+```
+
+Ese contenido se pega en `main.tex` en la zona de `thebibligrography`.

--- a/articulo/referencias/bibtex2item.py
+++ b/articulo/referencias/bibtex2item.py
@@ -1,0 +1,57 @@
+# filename: bibtex2item.py
+import sys
+
+bibtex = sys.stdin.read()
+r = bibtex.split('\n')
+i = 0
+while i < len(r):
+  line = r[i].strip()
+  if not line: i += 1
+  if '@' == line[0]:
+    code = line.split('{')[-1][:-1]
+    title = venue = volume = number = pages = year = publisher = authors = None
+    output_authors = []
+    i += 1
+    while i < len(r) and '@' not in r[i]:
+      line = r[i].strip()
+      #print(line)
+      if line.startswith("title"):
+        title = line.split('{')[-1][:-2]
+      elif line.startswith("journal"):
+        venue = line.split('{')[-1][:-2]
+      elif line.startswith("volume"):
+        volume = line.split('{')[-1][:-2]
+      elif line.startswith("number"):
+        number = line.split('{')[-1][:-2]
+      elif line.startswith("pages"):
+        pages = line.split('{')[-1][:-2]
+      elif line.startswith("year"):
+        year = line.split('{')[-1][:-2]
+      elif line.startswith("publisher"):
+        publisher = line.split('{')[-1][:-2]
+      elif line.startswith("author"):
+        authors = line[line.find("{")+1:line.rfind("}")]
+        for LastFirst in authors.split('and'):
+          lf = LastFirst.replace(' ', '').split(',')
+          if len(lf) != 2: continue
+          last, first = lf[0], lf[1]
+          output_authors.append("{}, {}.".format(last.capitalize(), first.capitalize()[0]))
+      i += 1
+
+    print("\\bibitem{%s}" % code)
+    if len(output_authors) == 1:
+      print(output_authors[0] + " {}. ".format(title), end=' ')
+    else:
+      print(", ".join(_ for _ in output_authors[:-1]) + " & " + output_authors[-1] + " {}. ".format(title), end=' ')
+    if venue:
+      print("{{\\em {}}}.".format(" ".join([_.capitalize() for _ in venue.split(' ')])), end=' ')
+      if volume:
+        sys.stdout.write(" \\textbf{{{}}}".format(volume))
+      if pages:
+        sys.stdout.write(", {}".format(pages) if number else " pp. {}".format(pages))
+      if year:
+        sys.stdout.write(" ({})".format(year))
+    if publisher and not venue:
+      print("({},{})".format(publisher, year))
+    print()
+    print()

--- a/articulo/trabajo-relacionado.tex
+++ b/articulo/trabajo-relacionado.tex
@@ -1,1 +1,2 @@
 \section{\label{sec:trabajo-relacionado} Related work}
+\cite{rad2017introduction}

--- a/articulo/trabajo-relacionado.tex
+++ b/articulo/trabajo-relacionado.tex
@@ -1,2 +1,20 @@
 \section{\label{sec:trabajo-relacionado} Related work}
-\cite{rad2017introduction}
+Rad, B. et al. \cite{rad2017introduction} presents a performance comparison between hypervisor-based and container-based technologies. 
+Three scenarios are under test: Docker vs KVM, LXC vs Xen and bare metal, Docker and KVM. 
+All scenarios show how container technologies exhibit a better performance when they are compared with hypervisor ones. 
+Experiments with Docker also show how its performance is close to the bare metal environment.
+Those experiments were not homogeneous. 
+When Docker was compared with KVM, an image processing test was carried out. 
+The LXC and Xen scenario run SQL queries.
+And bare metal, Docker and KVM; employed reading and writing I/O operations.
+The heterogeneity of the tests makes it difficult to state a clear picture about an overall performance of the different technologies under study.
+However, Docker showed a good overall performance.
+
+Torrez et. al. \cite{torrez2019hpc} studied three different HPC oriented container technologies: Charliecloud, Shifter and Singularity.
+These technologies were evaluated against industry-standard benchmarks (SysBench,  STREAM,  and  HPCG).
+These benchmarks are written in a wide range of programming languages such as: C, Python, Go, shell scripts amongst others.
+Experimental results show little performance degradation. 
+However, 1.8\% of memory degradation was found which authors stated is negligible. 
+They encourage to containerize applications because of the low impact exhibited by the technologies under study.
+Unfortunately, their results do not consider startup and teardown overhead. 
+This overhead is not negligible when many container instances are fired.


### PR DESCRIPTION
Adicionando dos referencias a trabajo relacionado.

Se incluye un directorio de referencias el cual tiene un script en Python que permite convertir una referencia en bibtex a bibitem. Si se encuentra otra forma de hacer esta conversion, excelente. Esta conversion se hace necesaria pues las referencias se estan definiendo en el 'main.tex' y sigue el esquema bibitem.