### PR TITLE
feat: stressng tests with increasing workers

### DIFF
--- a/codigo/LXD/pull_logs.sh
+++ b/codigo/LXD/pull_logs.sh
@@ -2,7 +2,11 @@
 CONTAINER=$1
 
 echo "Pull Stress-ng logs"
-lxc file pull $CONTAINER/root/StressNG/stress_ng.log logs/stress-ng.lxd.log
+for test in cpu io hdd vm dccp; do
+  for workers in 1 2 4 8 16 32 64; do  
+    lxc file pull $CONTAINER/root/StressNG/stressng.$test.$workers.log logs/stressng.$test.$workers.lxd.log
+  done
+done
 
 echo "Pull NPB logs"
 for j in cg ep ft; do

--- a/codigo/LXD/tests.sh
+++ b/codigo/LXD/tests.sh
@@ -2,7 +2,7 @@
 TIMEOUT=10
 
 # Run stress-ng benchmark
-cd /root/ && sh ./StressNG/run_test.sh -t $TIMEOUT -l /root/StressNG/stress_ng.log
+cd /root/ && sh ./StressNG/run_test.sh -t $TIMEOUT -l /root/StressNG
 
 # Run NPB benchmark
 NPBWD=/root/NPB/NPB3.4.1/NPB3.4-OMP/bin

--- a/codigo/StressNG/run_test.sh
+++ b/codigo/StressNG/run_test.sh
@@ -2,11 +2,18 @@
 while getopts ":t:l:" arg; do
   case $arg in
     t) TIMEOUT=$OPTARG;;
-    l) LOGFILE=$OPTARG;;
+    l) LOGLOC=$OPTARG;;
     \?) echo "Invalid option -$OPTARG" >&2
   esac
 done
 
-stress-ng --cpu 4 --io 4 --hdd 1 --hdd-bytes 2M --vm 2 --vm-bytes 2M --dccp 2 --timeout $TIMEOUT --metrics --log-file $LOGFILE
-
-echo "Modify line.10 to change stress-ng cpu/io/hdd/vm/dccp worker amount"
+for test in cpu io hdd vm dccp; do
+  for workers in 1 2 4 8 16 32 64; do    
+    echo "Running $test with $workers workers"
+    LOGFILE=$LOGLOC/stressng.$test.$workers.log
+    touch $LOGFILE
+    RUN="stress-ng --$test $workers --timeout $TIMEOUT --metrics --log-file $LOGFILE"
+    eval $RUN
+    echo "Log file in: $LOGFILE"
+  done
+done


### PR DESCRIPTION
`StressNG/run_test.sh` now can execute different test suites (cpu, io, hdd, vm, dccp) with 1 2 4 8 16 32 64 workers per each one with

```bash
for test in cpu io hdd vm dccp; do
  for workers in 1 2 4 8 16 32 64; do    
    echo "Running $test with $workers workers"
    LOGFILE=$LOGLOC/stressng.$test.$workers.log
    touch $LOGFILE
    RUN="stress-ng --$test $workers --timeout $TIMEOUT --metrics --log-file $LOGFILE"
    eval $RUN
    echo "Log file in: $LOGFILE"
  done
done
```