### PR TITLE
doc: StressNG benchmark documentation

### DIFF
--- a/codigo/LXD/Makefile
+++ b/codigo/LXD/Makefile
@@ -10,6 +10,9 @@ attach:
 run-tests:
 	sh run_tests.sh lxdtest
 
+push-files:
+	sh push_files.sh lxdtest
+
 pull-logs:
 	sh pull_logs.sh lxdtest
 

--- a/codigo/LXD/tests.sh
+++ b/codigo/LXD/tests.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/sh
-TIMEOUT=10
 
 # Run stress-ng benchmark
-cd /root/ && sh ./StressNG/run_test.sh -t $TIMEOUT -l /root/StressNG
+cd /root/ && sh ./StressNG/run_test.sh -t 60m -l /root/StressNG
 
 # Run NPB benchmark
 NPBWD=/root/NPB/NPB3.4.1/NPB3.4-OMP/bin

--- a/codigo/StressNG/Makefile
+++ b/codigo/StressNG/Makefile
@@ -1,0 +1,6 @@
+all:
+	mkdir -p $(shell pwd)/logs
+	sh ./run_test.sh -t 60m -l $(shell pwd)/logs
+
+install:
+	sh install.sh

--- a/codigo/StressNG/README.md
+++ b/codigo/StressNG/README.md
@@ -1,0 +1,19 @@
+# StressNG Benchmark Scripts
+
+# Configuración
+
+Para instalar la herramienta ejecutar el script `install.sh` ó ejecutar `make install`
+
+# Tests
+
+Para ejecutar las pruebas correr el script `run_test.sh` con 
+- `-t` para indicar el tiempo de ejecución de las pruebas, se recomienda usar 60m para un total de 35h
+- `-l` para indicar la carpeta donde se guardarán los logs. se recomienda que sea la misma ubicación del script. ejemplo:
+
+`sh /home/vagrant/StressNG/run_test.sh -t 60m -l /home/vagrant/StressNG`
+
+En la carpeta se guardarian diferentes archivos con la siguiente estructura en el nombre: `stressng.$test.$worker.log` donde `$test` puede tomar valores [cpu, io, hdd, vm, dccp] y `$worker` puede tomar valores [1, 2, 4, 8, 16, 32, 64]
+
+# Makefile
+
+Se dispone un archivo Makefile para ejecutar las pruebas con `make` con 60m por defecto de tiempo y la ubicación de los logs en la carpeta `logs/` junto al archivo Makefile


### PR DESCRIPTION
- fix: lxd stressng test timeout to 60m